### PR TITLE
Format-and-expand-markdown-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
 # java-license-auditor-cli
+
+[![ci](https://github.com/jpfulton/java-license-auditor-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/jpfulton/java-license-auditor-cli/actions/workflows/ci.yml)
+[![npm version](https://badge.fury.io/js/%40jpfulton%2Fjava-license-auditor-cli.svg)](https://www.npmjs.com/package/@jpfulton/java-license-auditor-cli)
+![License](https://img.shields.io/badge/License-MIT-blue)
+![Visitors](https://visitor-badge.laobi.icu/badge?page_id=jpfulton.java-license-auditor-cli)
+
+A CLI designed to list and audit licenses in project dependencies in Java projects. The CLI
+can output both markdown reports and CSV files and is designed to run in CI workflows.
+Included in the package is a [DangerJS](https://danger.systems/js) plugin that can be
+used to audit licenses in the PR process.
+
+In current state, only Java projects using Maven are supported.
+
+## Installation of the CLI
+
+You can install this tool globally, using the following yarn command:
+
+```bash
+yarn global add @jpfulton/java-license-auditor-cli
+```
+
+## Local Configuration
+
+To override the default configuration, which is extremely minimal, place a `.license-checker.json` file in the
+root directory of your project with the following format:
+
+```json
+{
+  "blackList": ["blacklisted-license"],
+  "whiteList": ["whitelisted-license"]
+}
+```
+
+Licenses in the blackList array will generate errors in the report. Licenses in the
+whiteList array will generate information lines and licenses types that exist in neither
+array generate warnings for further investigation.
+
+## Remote Configurations
+
+Remote configurations can be used to override the default configuration. To use a remote
+configuration, specify the URL to the configuration file using the `--remote-config` flag.
+Remote configurations are useful when applying the same configuration to multiple projects
+to avoid the need to copy the configuration file to each project and maintain the configurations
+in multiple places.
+
+```bash
+java-license-auditor-cli csv --remote-config https://raw.githubusercontent.com/jpfulton/node-license-auditor-cli/main/.license-checker.json . > report.csv
+```
+
+```bash
+java-license-auditor-cli markdown --remote-config https://raw.githubusercontent.com/jpfulton/node-license-auditor-cli/main/.license-checker.json . > report.md
+```
+
+## Usage as a DangerJS Plugin
+
+This project can be used as a [DangerJS](https://danger.systems/js/) plugin. To use the
+plugin, install the plugin using the following command:
+
+```bash
+yarn add -D danger @jpfulton/java-license-auditor-cli
+```
+
+Then, add the following to your `dangerfile.ts`:
+
+```typescript
+import { javaLicenseAuditor } from "@jpfulton/java-license-auditor-cli";
+
+export default async () => {
+  // Run the license auditor plugin
+  await licenseAuditor({
+    // optionally choose to fail the build if a blacklisted license is found
+    failOnBlacklistedLicense: false,
+    // specify the path to the project's package.json file, useful in a monorepo
+    // defaults to the current working directory
+    projectPath: ".",
+    // optionally specify a remote configuration file
+    // useful when applying the same configuration to multiple projects
+    // defaults to usage of a local configuration file found at the root of the project repo
+    remoteConfigurationUrl:
+      "https://raw.githubusercontent.com/jpfulton/jpfulton-license-audits/main/.license-checker.json",
+    // show a summary of the license audit in the PR comment
+    // includes the number of unique dependencies and counts for each category of license found
+    showMarkdownSummary: true,
+    // show details of the license audit in the PR comment
+    // includes a table with the name, version and license of each dependency
+    // that was discovered that was not explicitly whitelisted in the configuration
+    showMarkdownDetails: true,
+  });
+};
+```

--- a/src/commands/audit-to-markdown.ts
+++ b/src/commands/audit-to-markdown.ts
@@ -4,6 +4,7 @@ import {
   getConfiguration,
   getConfigurationFromUrl,
   getCurrentVersionString,
+  getLicensesMarkdown,
   getRootProjectName,
 } from "../util";
 
@@ -80,10 +81,12 @@ const errorMarkdown = (licenseObj: License) => {
 };
 
 const markdown = (icon: string, licenseItem: License): string => {
+  const licenseString = getLicensesMarkdown(licenseItem);
+
   return `| ${icon} 
 | ${licenseItem.name} 
 | ${licenseItem.version} 
-| ${licenseItem.licenses} 
+| ${licenseString} 
 | ${licenseItem.publisher ?? ""} 
 | ${licenseItem.email ?? ""} 
 | ${licenseItem.repository ?? ""} 

--- a/src/danger/danger-plugin.ts
+++ b/src/danger/danger-plugin.ts
@@ -9,6 +9,7 @@ import {
   getConfiguration,
   getConfigurationFromUrl,
   getCurrentVersionString,
+  getLicensesMarkdown,
 } from "../util";
 
 const repositoryUrl = "https://github.com/jpfulton/java-license-auditor-cli";
@@ -144,10 +145,8 @@ const errorOutputter: LicenseOutputter = (license: License) => {
 };
 
 const markdownOutputter = (icon: string, license: License) => {
-  const { name, version, licenses } = license;
-  const licenseString = Array.isArray(licenses)
-    ? licenses.join(", ")
-    : licenses;
+  const { name, version } = license;
+  const licenseString = getLicensesMarkdown(license);
 
   return `| ${icon} | ${name} | ${version} | ${licenseString} |`;
 };

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -3,7 +3,8 @@ export interface License {
   name: string;
   path?: string;
   licenses: string[] | string;
-  licensePath: string;
+  licenseUrl?: (string | undefined)[] | string;
+  licensePath?: string;
   repository: string;
   publisher: string;
   email?: string;

--- a/src/util/converters.ts
+++ b/src/util/converters.ts
@@ -12,12 +12,12 @@ export const convertMavenDependencyToLicense = (
       mavenDependency.licenses?.map(
         (mavenLicense: MavenLicense) => mavenLicense.name
       ) || [],
+    licenseUrl:
+      mavenDependency.licenses?.map(
+        (mavenLicense: MavenLicense) => mavenLicense.url
+      ) || "",
     publisher: mavenDependency.groupId,
     repository: mavenDependency.url || "",
-    licensePath:
-      mavenDependency.licenses
-        ?.map((mavenLicense: MavenLicense) => mavenLicense.url)
-        .join(", ") || "",
   };
 
   return license;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,6 +4,7 @@ import {
   convertMavenDependencyToLicense,
 } from "./converters.js";
 import { removeDuplicates } from "./duplicate-remover.js";
+import { getLicensesMarkdown } from "./markdown-helpers.js";
 import { LicenseOutputter, MetadataOutputter } from "./outputters.js";
 import {
   getCurrentVersionString,
@@ -20,6 +21,7 @@ export {
   getConfiguration,
   getConfigurationFromUrl,
   getCurrentVersionString,
+  getLicensesMarkdown,
   getRootProjectName,
   isGradleProject,
   isMavenProject,

--- a/src/util/markdown-helpers.ts
+++ b/src/util/markdown-helpers.ts
@@ -1,0 +1,39 @@
+import { License } from "../models";
+
+export const getLicensesMarkdown = (license: License) => {
+  const { licenses, licenseUrl } = license;
+
+  // both licenses and licenseUrl need to be arrays or strings
+  // licenseUrl can be undefined if licenses is a string
+  // licenseUrl can be an array of undefined if licenses is an array
+  // if these cases are not met, we need to throw an error
+  if (
+    (Array.isArray(licenses) && !Array.isArray(licenseUrl)) ||
+    (!Array.isArray(licenses) && Array.isArray(licenseUrl))
+  ) {
+    throw new Error(
+      `The license and licenseUrl properties of the license object must both be arrays or strings.`
+    );
+  }
+
+  let licenseString = "";
+
+  // construct a markdown link if we have a licenseUrl
+  if (Array.isArray(licenses) && Array.isArray(licenseUrl)) {
+    // we can expect the arrays to be the same length and that
+    // the index of the licenseUrl will match the index of the license
+    licenseString = licenseUrl
+      .map((url, index) =>
+        url ? `[${licenses[index]}](${url})` : licenses[index]
+      )
+      .join("; ");
+  } else if (licenseUrl) {
+    licenseString = licenseUrl
+      ? `[${licenses}](${licenseUrl})`
+      : (licenses as string);
+  } else {
+    licenseString = licenses as string;
+  }
+
+  return licenseString;
+};

--- a/src/util/markdown-helpers.ts
+++ b/src/util/markdown-helpers.ts
@@ -28,9 +28,7 @@ export const getLicensesMarkdown = (license: License) => {
       )
       .join("; ");
   } else if (licenseUrl) {
-    licenseString = licenseUrl
-      ? `[${licenses}](${licenseUrl})`
-      : (licenses as string);
+    licenseString = `[${licenses}](${licenseUrl})`;
   } else {
     licenseString = licenses as string;
   }

--- a/tests/danger/javaLicenseAuditor.test.ts
+++ b/tests/danger/javaLicenseAuditor.test.ts
@@ -50,6 +50,7 @@ describe("javaLicenseAuditor", () => {
         {
           licensePath: "test",
           licenses: ["UNKNOWN"],
+          licenseUrl: [undefined],
           name: "test",
           version: "test",
           repository: "test",
@@ -84,6 +85,7 @@ describe("javaLicenseAuditor", () => {
         {
           licensePath: "test",
           licenses: ["UNKNOWN"],
+          licenseUrl: [undefined],
           name: "test",
           version: "test",
           repository: "test",
@@ -118,6 +120,7 @@ describe("javaLicenseAuditor", () => {
         {
           licensePath: "test",
           licenses: ["UNKNOWN"],
+          licenseUrl: [undefined],
           name: "test",
           version: "test",
           repository: "test",
@@ -180,6 +183,7 @@ describe("javaLicenseAuditor", () => {
         {
           licensePath: "test",
           licenses: ["Test1", "Test2"],
+          licenseUrl: [undefined, undefined],
           name: "test",
           version: "test",
           repository: "test",

--- a/tests/util/converters.test.ts
+++ b/tests/util/converters.test.ts
@@ -27,7 +27,7 @@ describe("convertMavenDependencyToLicense", () => {
       name: "com.example:example",
       version: "1.0.0",
       licenses: ["MIT"],
-      licensePath: "https://opensource.org/licenses/MIT",
+      licenseUrl: ["https://opensource.org/licenses/MIT"],
       repository: "https://example.com",
       publisher: "com.example",
       rootProjectName: "com.example:root-project",
@@ -64,8 +64,10 @@ describe("convertMavenDependencyToLicense", () => {
       name: "com.example:example",
       version: "1.0.0",
       licenses: ["MIT", "Apache-2.0"],
-      licensePath:
-        "https://opensource.org/licenses/MIT, https://opensource.org/licenses/Apache-2.0",
+      licenseUrl: [
+        "https://opensource.org/licenses/MIT",
+        "https://opensource.org/licenses/Apache-2.0",
+      ],
       repository: "https://example.com",
       publisher: "com.example",
       rootProjectName: "com.example:root-project",

--- a/tests/util/markdown-helpers.test.ts
+++ b/tests/util/markdown-helpers.test.ts
@@ -1,0 +1,146 @@
+import { getLicensesMarkdown } from "../../src/util/markdown-helpers.js";
+import { License } from "../../src/models";
+
+describe("getLicensesMarkdown", () => {
+  it("should return a markdown string for a license with a single license and no url", () => {
+    const license = {
+      rootProjectName: "test-project",
+      name: "test-package",
+      repository: "https://github.com/test/test-package",
+      publisher: "Test Publisher",
+      version: "1.0.0",
+      licenses: "MIT",
+      licenseUrl: undefined,
+    };
+
+    const expected = "MIT";
+
+    const actual = getLicensesMarkdown(license);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should return a markdown string for a license with a single license and a url", () => {
+    const license = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: "MIT",
+      licenseUrl: "https://opensource.org/licenses/MIT",
+    };
+
+    const expected = "[MIT](https://opensource.org/licenses/MIT)";
+
+    const actual = getLicensesMarkdown(license);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should return a markdown string for a license with multiple licenses and multiple urls", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: ["MIT", "Apache-2.0"],
+      licenseUrl: [
+        "https://opensource.org/licenses/MIT",
+        "https://opensource.org/licenses/Apache-2.0",
+      ],
+    };
+
+    const expected =
+      "[MIT](https://opensource.org/licenses/MIT); [Apache-2.0](https://opensource.org/licenses/Apache-2.0)";
+
+    const actual = getLicensesMarkdown(license);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should return a markdown string for a license with multiple licenses and a single url", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: ["MIT", "Apache-2.0"],
+      licenseUrl: ["https://opensource.org/licenses/MIT", undefined],
+    };
+
+    const expected = "[MIT](https://opensource.org/licenses/MIT); Apache-2.0";
+
+    const actual = getLicensesMarkdown(license);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should return a markdown string for a license with multiple licenses and no urls", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: ["MIT", "Apache-2.0"],
+      licenseUrl: [undefined, undefined],
+    };
+
+    const expected = "MIT; Apache-2.0";
+
+    const actual = getLicensesMarkdown(license);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("should throw an error if the license and licenseUrl properties are not both arrays or strings", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: ["MIT", "Apache-2.0"],
+      licenseUrl: "https://opensource.org/licenses/MIT",
+    };
+
+    expect(() => getLicensesMarkdown(license)).toThrowError(
+      "The license and licenseUrl properties of the license object must both be arrays or strings."
+    );
+  });
+
+  it("should throw an error if the license and licenseUrl properties are not both arrays or strings", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: "MIT",
+      licenseUrl: ["https://opensource.org/licenses/MIT", undefined],
+    };
+
+    expect(() => getLicensesMarkdown(license)).toThrowError(
+      "The license and licenseUrl properties of the license object must both be arrays or strings."
+    );
+  });
+
+  it("should throw an error if the license and licenseUrl properties are not both arrays or strings", () => {
+    const license: License = {
+      rootProjectName: "",
+      name: "",
+      repository: "",
+      publisher: "",
+      version: "",
+      licenses: ["MIT", "Apache-2.0"],
+      licenseUrl: undefined,
+    };
+
+    expect(() => getLicensesMarkdown(license)).toThrowError(
+      "The license and licenseUrl properties of the license object must both be arrays or strings."
+    );
+  });
+});


### PR DESCRIPTION
Updated to have markdown output formats provide links to licenses online if available. README updated for project.